### PR TITLE
Add announcements back to navbar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,6 +5,9 @@ main:
     url: "/get-involved"
   - label: "Code of Conduct"
     url: "/code-of-conduct"
+  - label: "Announcements"
+    url: "/announcements"
+    collection: true
   - label: "Hacknights"
     url: "/hacknights"
     collection: true
@@ -29,9 +32,6 @@ utility:
 
 # Secondary navigation items are currently not used in navigation feautures.
 secondary:
-  - label: "Announcements"
-    url: "/announcements"
-    collection: true
   - label: "People"
     url: "/people"
     collection: true


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of your changes -->

- Adds a link to past announcements back to the navigation bar

## How to Test

<!-- List how to test what you've done -->

- [ ] Open navbar and check that Announcements is there
- [ ] Click on Announcements to see all past announcements (external contents not loaded during local testing)

## Screenshots or Recording (if applicable)

<!-- Add screenshots here if there are UI changes -->

On desktop:

<img width="1636" height="841" alt="image" src="https://github.com/user-attachments/assets/bf7baa68-01d7-4a2f-a2a1-8077ac3e37c5" />

On mobile:

<img width="368" height="615" alt="image" src="https://github.com/user-attachments/assets/c08a1553-f741-4a9c-aa1d-30da8119ca56" />

## To Do

<!-- Flag anything left to do -->

- N/A
