### PR TITLE
Add mastodon social button to footer

### DIFF
--- a/_data/footer_social.yml
+++ b/_data/footer_social.yml
@@ -24,6 +24,11 @@ bluesky:
   url: "https://bsky.app/profile/civictechto.bsky.social"
   icon: bluesky.svg
 
+mastodon:
+  label: Mastodon
+  url: "https://mstdn.ca/@CivicTechTO"
+  icon: mastodon.svg
+  
 instagram:
   label: Instagram
   url: "https://www.instagram.com/civictechto/"


### PR DESCRIPTION
## Summary
Add social link to our official mastodon account in the footer

## Testing
Go to http://localhost:4000 and confirm the mastodon URL, button and link is working
Tested on my side and it works

Fixes #42 

