### PR TITLE
inclusion of manually set featured topics

### DIFF
--- a/_data/featured_topics.yml
+++ b/_data/featured_topics.yml
@@ -1,0 +1,15 @@
+# Featured topics to display on the homepage
+# Each topic should match a slug from _data/tags.yml
+topics:
+  - slug: democracy
+    title: Democracy
+  - slug: climate
+    title: Climate
+  - slug: housing
+    title: Housing
+  - slug: open-data
+    title: Open Data
+  - slug: public-engagement
+    title: Public Engagement
+  - slug: artificial-intelligence
+    title: Artificial Intelligence

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -198,6 +198,24 @@ permalink: "/"
 
 </section>
 
+<!-- === Featured Topics ===  -->
+
+<section>
+  <header>
+    <h2>Explore Topics</h2>
+  </header>
+  <div class="feautured-topic-links">
+    {% for topic in site.data.featured_topics.topics %}
+      <a role="button" class="outline" href="{{ '/tags/topic/' | append: topic.slug | append: '/' | relative_url }}">
+        {{ topic.title }}
+      </a>
+    {% endfor %}
+  </div>
+  <div class="frontpage-action">
+    <a href="{{ '/tags/topic' | relative_url }}">See all topics here.</a>
+  </div>
+</section>
+
 <!-- === Call to Actions ===  -->
 
 <section>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -100,7 +100,7 @@ dd {
 }
 
 /* Breadcrumb */
-nav[aria-label='breadcrumb'] {
+nav[aria-label="breadcrumb"] {
   margin-bottom: var(--pico-spacing);
 }
 
@@ -345,8 +345,8 @@ header.sticky {
 .main-with-sidebar {
   display: grid;
   grid-template-areas:
-    'main'
-    'sidebar';
+    "main"
+    "sidebar";
   grid-template-columns: 1fr;
   gap: 1.5rem;
   margin-bottom: 2rem;
@@ -363,7 +363,7 @@ header.sticky {
 /* Two-column layout on tablet+ */
 @media (min-width: 1024px) {
   .main-with-sidebar {
-    grid-template-areas: 'main sidebar';
+    grid-template-areas: "main sidebar";
     grid-template-columns: 2fr 1fr; /* or 3fr 1fr depending on your balance */
   }
 }
@@ -520,4 +520,12 @@ aside .ogimage {
 
 .listed {
   max-width: 450px;
+}
+
+.feautured-topic-links {
+  /* Home page featured topic links */
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding-bottom: 1rem;
 }


### PR DESCRIPTION
## Description


- Included a homepage section for manually set topic links. Topics are defined by `_data/featured_topics.yml`
- this is a minor edit

## Screenshots or Recording (if applicable)


<img width="1364" height="415" alt="Screenshot 2025-11-30 at 1 11 33 PM" src="https://github.com/user-attachments/assets/e45b4559-4f60-4584-9e96-062d9c53fd19" />
<img width="420" height="425" alt="Screenshot 2025-11-30 at 1 11 50 PM" src="https://github.com/user-attachments/assets/3d8c1f0c-57f4-420a-a4f1-08c4e1a90660" />
