### PR TITLE
Fix workflow to work with branch protection rules

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -2,7 +2,7 @@ name: Update Archives Submodule and Trigger Pages Build
 
 on:
   schedule:
-    - cron: '0 * * * *'  # every hour
+    - cron: '0 0 * * *'  # daily at midnight UTC
   workflow_dispatch:
 
 jobs:
@@ -23,9 +23,17 @@ jobs:
       - name: Update 'archives' submodule
         run: |
           git submodule update --remote archives
-          git add archives
-          git commit -m "Auto-update archives submodule to latest master" || echo "No changes to commit"
 
-      - name: Push changes if any
-        run: |
-          git push || echo "Nothing to push"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "Auto-update archives submodule to latest master"
+          title: "Auto-update archives submodule"
+          body: |
+            Automated update of the archives submodule to the latest commit.
+
+            🤖 This PR was created automatically by the scheduled workflow.
+          branch: auto-update-archives
+          delete-branch: true
+          add-paths: |
+            archives


### PR DESCRIPTION
- Change workflow to create PRs instead of pushing directly to main
- Reduce cron schedule from hourly to daily for resource efficiency
- Use peter-evans/create-pull-request action to respect branch protection

This resolves the repository rule violation where the automated workflow was blocked from pushing directly to main.