### PR TITLE
Add support for rel attribute on footer social links for Mastodon verification

### DIFF
--- a/_data/footer_social.yml
+++ b/_data/footer_social.yml
@@ -28,7 +28,9 @@ mastodon:
   label: Mastodon
   url: "https://mstdn.ca/@CivicTechTO"
   icon: mastodon.svg
-  
+  rel: "me"
+
+
 instagram:
   label: Instagram
   url: "https://www.instagram.com/civictechto/"

--- a/_includes/social-links-footer.html
+++ b/_includes/social-links-footer.html
@@ -38,7 +38,13 @@ Optional:
       {% assign label = social_data.label | default: key %}
 
       {% if url %}
-        <a href="{{ url }}" target="_blank" rel="noopener" class="social-button">
+        {% assign extra_rel = details.rel %}
+        {% if extra_rel %}
+          {% assign rel_value = extra_rel | append: " noopener" %}
+        {% else %}
+          {% assign rel_value = "noopener" %}
+        {% endif %}
+        <a href="{{ url }}" target="_blank" rel="{{ rel_value }}" class="social-button">
           {% if custom_icon %}
             <span class="iconstyle">{% include icons/{{ custom_icon }} %}</span>
           {% elsif custom_emoji %}


### PR DESCRIPTION
## Description

Adds optional `rel` field to footer_social.yml entries. When set, the value is prepended to the existing `noopener` on the anchor tag (e.g. `rel="me noopener"`). Sets `rel: "me"` on the Mastodon entry to satisfy Mastodon profile URL verification.

Closes CivicTechTO/civictech.ca#71

## How to Test

Go to localhost:4000
Confirm the mastodon link in the footer has the "me" attribute value

## To Do

Nothing