### PR TITLE
Fix stale upcoming events by adding scheduled weekly rebuild

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,8 @@ on:
       - main # Adjust if your default branch is different
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 3'  # Every Wednesday at noon UTC (after Tuesday Hacknight events)
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
## Problem

The site was displaying past Hacknight events as "upcoming" because the Jekyll build had not run since December 9th. Jekyll is a static site generator — event dates are evaluated at build time. Once built, if no new push or manual dispatch occurs, the HTML stays stale indefinitely even as real-world dates pass.

The existing `update-submodule.yml` runs daily but only creates a PR when the `archives` submodule has new commits. If no new events are added to the archive (common between Hacknights), no PR is created, no rebuild fires, and stale "upcoming events" persist.

## Root Cause

`pages.yml` had no `schedule` trigger — only `push` to `main` and `workflow_dispatch`. There was no mechanism to automatically invalidate the stale static build as time passed.

## Fix

Add a `schedule` trigger to `pages.yml`:

```yaml
schedule:
  - cron: '0 12 * * 3'  # Every Wednesday at noon UTC
```

Wednesday noon UTC (8am EDT / 7am EST) fires after each Tuesday Hacknight, ensuring the site rebuilds and re-evaluates event dates weekly.

## References

Closes the issue raised about stale upcoming events. Related to #54.