### PR TITLE
Refactor excerpt and description handling for consistency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ github_username: civictechto
 
 timezone: America/Toronto
 future: true
+page_excerpts: true
 
 include:
   - _pages

--- a/_includes/jsonld.html
+++ b/_includes/jsonld.html
@@ -71,11 +71,12 @@ Note:
     "url": {{ page.url | absolute_url | jsonify }}
 
   {% elsif page_tags contains "type/meetup" %}
+    {% assign meetup_description = page.description | default: page.content | strip_html | strip_newlines | truncatewords: 50 %}
     "@type": "Event",
     "name": {{ page.title | jsonify }},
     "startDate": "{{ page.date }}",
     "endDate": "{{ page.date }}",
-    "description": {{ page.description | strip_html | strip_newlines | jsonify }},
+    "description": {{ meetup_description | jsonify }},
     {% if page.venue %}
       "location": {
         "@type": "Place",

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -45,9 +45,6 @@ layout: base
     <div class="main-with-sidebar">
       <div class="main-content">
         <section class="project-description">
-          {% if page.description %}
-          <p>{{ page.description }}</p>
-          {% endif %}
           {{ content }}
         </section>
       </div>

--- a/_layouts/resource.html
+++ b/_layouts/resource.html
@@ -14,16 +14,13 @@ layout: base
     <header>
       <hgroup>
         <h1>{{ page.title }}</h1>
-        {% if page.excerpt %}
-          <p>{{ page.excerpt }}</p>
+        {% if page.description %}
+          <p>{{ page.description }}</p>
         {% endif %}
       </hgroup>
     </header>
 
     <section class="resource-details">
-      {% if page.description %}
-        <p>{{ page.description }}</p>
-      {% endif %}
 
       {% if page.website %}
         <p>


### PR DESCRIPTION
## Summary

Fixes inconsistent use of `excerpt` and `description` fields across layouts and JSON-LD. Two fields serve distinct roles:
- **`excerpt`** — short tagline, shown in `<hgroup>` subtitle and card listings
- **`description`** — longer body copy, shown in main content area

## Changes

- **`_config.yml`**: Add `page_excerpts: true` so Jekyll 4.1.1+ auto-generates `page.excerpt` for pages (not just posts), enabling the subtitle in `page.html` to render without requiring manual front matter
- **`_layouts/resource.html`**: Move `description` from body section to `<hgroup>` subtitle — resources use `description` in front matter (not `excerpt`), so the old header check was always dead; description is a one-liner that belongs in the subtitle position
- **`_layouts/project.html`**: Remove dead `{% if page.description %}` body block — projects use `excerpt` (already shown in the header); `description` was almost never set in project front matter
- **`_includes/jsonld.html`**: Fix meetup `Event` Schema.org description — was always outputting an empty string because meetups have no `description` front matter field; now falls back to page body content (stripped, truncated to 50 words)

## Test plan

- [ ] Resource detail page shows description as subtitle beneath title
- [ ] Project detail page renders correctly (no regression)
- [ ] View source on a meetup page — JSON-LD `description` field is now populated
- [ ] Pages with `excerpt` in front matter still render subtitle correctly

Closes #63