### PR TITLE
fix: add aria-label to footer theme switcher nav (#93)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,7 +21,7 @@ Make sure your site has:
     </div>
   </div>
   <hr/>
-  <nav>
+  <nav aria-label="Theme switcher">
     <ul><li><strong>Change Theme</strong></li></ul>
     <ul>
       <li><a href="#" data-theme-switcher="auto">Auto</a></li>


### PR DESCRIPTION
﻿## Summary

Adds aria-label="Theme switcher" to the footer theme switcher navigation.

Without this label, screen readers may not be able to distinguish this navigation landmark from other nav elements on the page.

## Changes

- _includes/footer.html: add aria-label="Theme switcher" to the footer theme switcher nav

## Testing

- Reviewed the HTML change locally
- Not run locally: Ruby/Bundler is not installed on my machine
- CI will run the Jekyll build and Pa11y WCAG2AA checks

Fixes #93
