### PR TITLE
Replace excerpts with new summary field

### DIFF
--- a/_includes/jsonld.html
+++ b/_includes/jsonld.html
@@ -12,7 +12,7 @@ It determines the appropriate @type based on page.tags:
 
 Requirements:
   - Pages should have appropriate tags in front matter
-  - Optional fields supported: excerpt, description, dateActiveFirst, organization, venue, videoUrl, social.website, parent_organization, speakers, etc.
+  - Optional fields supported: summary, description, dateActiveFirst, organization, venue, videoUrl, social.website, parent_organization, speakers, etc.
   - Uses Liquid's `jsonify` filter to safely escape string values
 
 Note:
@@ -29,8 +29,8 @@ Note:
   {% if page_tags contains "type/project" %}
     "@type": "CreativeWork",
     "name": {{ page.title | jsonify }},
-    {% if page.excerpt %}
-      "description": {{ page.excerpt | strip_html | strip_newlines | jsonify }},
+    {% if page.summary %}
+      "description": {{ page.summary | strip_html | strip_newlines | jsonify }},
     {% endif %}
     {% if page.dateActiveFirst %}
       "dateCreated": "{{ page.dateActiveFirst }}",

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,8 +13,8 @@ layout: base
     <header>
       <hgroup>
         <h1>{{ page.display_title | default: page.title }}</h1>
-        {% if page.excerpt %}
-          <p>{{ page.excerpt }}</p>
+        {% if page.summary %}
+          <p>{{ page.summary }}</p>
         {% endif %}
       </hgroup>
     </header>

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -14,8 +14,8 @@ layout: base
     <header>
       <hgroup>
         <h1>{{ page.title }}</h1>
-        {% if page.excerpt %}
-          <p>{{ page.excerpt }}</p>
+        {% if page.summary %}
+          <p>{{ page.summary }}</p>
         {% endif %}
       </hgroup>
     </header>
@@ -85,8 +85,8 @@ layout: base
     </footer>
   </article>
 
-  {% include backlinks.html 
-    collections=all_collections 
+  {% include backlinks.html
+    collections=all_collections
     fields="team,speakers"
     title="Mentioned In"
   %}

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -37,8 +37,8 @@ layout: base
     <header>
       <hgroup>
         <h1>{{ page.title }}</h1>
-        {% if page.excerpt %}
-          <p>{{ page.excerpt }}</p>
+        {% if page.summary %}
+          <p>{{ page.summary }}</p>
         {% endif %}
       </hgroup>
     </header>
@@ -81,7 +81,7 @@ layout: base
     {% if resolved_people.size > 0 %}
     <section>
       <h3>Related People</h3>
-      
+
       <article>
         <ul>
           {% for person in resolved_people %}

--- a/_pages/feedback.md
+++ b/_pages/feedback.md
@@ -2,7 +2,7 @@
 title: "Share Your Feedback"
 layout: page
 permalink: "/feedback/"
-excerpt: "🔓 Help us make Civic Tech Toronto better. Responses are anonymous — we never collect names or emails — and are stored openly in a public GitHub repository."
+summary: "🔓 Help us make Civic Tech Toronto better. Responses are anonymous — we never collect names or emails — and are stored openly in a public GitHub repository."
 ---
 
 <style>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -178,8 +178,8 @@ permalink: "/"
         <div class="row-content">
           <div>
             <h3><a href="{{ project.url }}">{{ project.title }}</a></h3>
-            {% if project.excerpt %}
-              <p>{{ project.excerpt }}</p>
+            {% if project.summary %}
+              <p>{{ project.summary }}</p>
             {% endif %}
             {% if project.tags %}
               {% include topic-tags.html tags=project.tags %}

--- a/_pages/list-announcements.md
+++ b/_pages/list-announcements.md
@@ -27,8 +27,8 @@ permalink: "/announcements/"
               {% endif %}
               </small>
             </p>
-            {% if post.excerpt %}
-              <p>{{ post.excerpt }}</p>
+            {% if post.summary %}
+              <p>{{ post.summary }}</p>
             {% else %}
               <p>{{ post.content | strip_html | truncatewords: 30 }}</p>
             {% endif %}

--- a/_pages/list-projects.md
+++ b/_pages/list-projects.md
@@ -41,8 +41,8 @@ permalink: "/projects/"
           {% endif%}
         <div class="card-body">
           <h3><a href="{{ project.url }}">{{ project.title }}</a></h3>
-          {% if project.excerpt %}
-            <p>{{ project.excerpt }}</p>
+          {% if project.summary %}
+            <p>{{ project.summary }}</p>
           {% endif %}
           {% if project.tags %}
             {% include topic-tags.html tags=project.tags %}
@@ -88,8 +88,8 @@ permalink: "/projects/"
           {% endif%}
           <div>
             <h3><a href="{{ project.url }}">{{ project.title }}</a></h3>
-            {% if project.excerpt %}
-              <p>{{ project.excerpt }}</p>
+            {% if project.summary %}
+              <p>{{ project.summary }}</p>
             {% endif %}
             {% if project.tags %}
               {% include topic-tags.html tags=project.tags %}
@@ -137,8 +137,8 @@ permalink: "/projects/"
 
           <div>
             <h3><a href="{{ project.url }}">{{ project.title }}</a></h3>
-            {% if project.excerpt %}
-              <p>{{ project.excerpt }}</p>
+            {% if project.summary %}
+              <p>{{ project.summary }}</p>
             {% endif %}
             {% if project.tags %}
               {% include topic-tags.html tags=project.tags %}


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of your changes -->

- This PR replaces the `excerpt` field with a new `summary` field.
- Currently, code in various pages checks if `excerpt` exists and then displays it. However, Jekyll creates an `excerpt` of the first paragraph by default, defeating the purpose of this check, and leading to content duplication. I believe the intent of the check is to only provide the excerpt if we've explicitly written one. 

## How to Test

<!-- List how to test what you've done -->

- [x] Built locally and checked a sample of impacted pages for issues

## Screenshots or Recording (if applicable)

<!-- Add screenshots here if there are UI changes -->

**Before - note the duplicated text, as no excerpt was provided:**

<img width="1653" height="995" alt="image" src="https://github.com/user-attachments/assets/625f3407-af25-446e-86ed-86563f42b74f" />

**After:**

<img width="1184" height="764" alt="image" src="https://github.com/user-attachments/assets/8099f50c-7018-4d78-bd66-1052cc2c88ef" />

## To Do

<!-- Flag anything left to do -->

- After merging this PR, will have to update the `archives` submodule so that records with `excerpt` use the new `summary` field. This will lead to temporary loss of visible excerpts on the website until the `archives` are updated.
- I will update `archives` as needed.
