### PR TITLE
Change our mastodon URL instance

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/_data/footer_social.yml
+++ b/_data/footer_social.yml
@@ -26,7 +26,7 @@ bluesky:
 
 mastodon:
   label: Mastodon
-  url: "https://mstdn.ca/@CivicTechTO"
+  url: "https://thecanadian.social/@CivicTechTO"
   icon: mastodon.svg
   rel: "me"
 


### PR DESCRIPTION
## Description

change our mastodon URL instance since we just migrated

https://thecanadian.social/@CivicTechTO


## How to Test

Ensure the URL in the social footer is pointing to the new URL
