### PR TITLE
Fix #149: Add absolute URL to sitemap in robots.txt

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ description: >-
 
 feedback_token: ""
 
+url: "https://civictech.ca"
 baseurl: ""
 github_username: civictechto
 


### PR DESCRIPTION
Closes #149. This sets the `url` field in `_config.yml`, which causes `jekyll-sitemap` to generate an absolute URL in `robots.txt`, fixing the Lighthouse audit failure.