### PR TITLE
Add robots.txt with absolute Sitemap URL

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://civictech.ca/sitemap.xml


### PR DESCRIPTION
## Summary
- Lighthouse flagged `robots.txt` as invalid: the `Sitemap:` directive was a relative path (`/sitemap.xml`), which violates the spec requiring an absolute URL.
- No `robots.txt` existed in this repo — it's auto-generated by the `jekyll-sitemap` gem with a relative Sitemap URL. Adding a root-level `robots.txt` overrides that default with the correct absolute URL.

Fixes #160

## Test plan
- [ ] After merge/deploy, confirm `https://civictech.ca/robots.txt` serves the new content (`Sitemap: https://civictech.ca/sitemap.xml`)
- [ ] Re-run Lighthouse SEO audit and confirm "robots.txt is valid" passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)