### PR TITLE
Defer render-blocking local scripts in base layout

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -37,9 +37,9 @@
 
   {% include footer.html %}
 
-  <script src="{{ site.baseurl }}/assets/js/minimal-theme-switcher.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/modal.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/navigation.js"></script>
+  <script defer src="{{ site.baseurl }}/assets/js/minimal-theme-switcher.js"></script>
+  <script defer src="{{ site.baseurl }}/assets/js/modal.js"></script>
+  <script defer src="{{ site.baseurl }}/assets/js/navigation.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Lighthouse flagged `minimal-theme-switcher.js`, `modal.js`, and `navigation.js` as render-blocking (~150ms+ estimated savings).
- All three are already the last elements in `<body>`, so adding `defer` lets the browser fetch them in parallel without blocking HTML parsing, while preserving their execution order (defer scripts run in document order, same as today).

Fixes #158

## Test plan
- [ ] Load the site locally (`make serve`) and confirm theme switcher and mobile nav/modal still work as expected
- [ ] Re-run Lighthouse and confirm the "Render-blocking requests" audit no longer flags these three scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)