### PR TITLE
Add explicit width/height to homepage hero image

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -9,6 +9,8 @@ permalink: "/"
     <img
       src="{{ 'assets/images/CivicTechTO-InPerson.jpg' | relative_url }}"
       alt="Picture of a group of people sitting listening to a presentation at a Civic Tech Toronto Meetup"
+      width="1037"
+      height="758"
       style="border-radius: 4px;"
     />
   </figure>


### PR DESCRIPTION
## Summary
- Lighthouse flagged the homepage hero image (`assets/images/CivicTechTO-InPerson.jpg`) as missing explicit dimensions, contributing to a Cumulative Layout Shift score of 0.197.
- Added the image's intrinsic `width="1037" height="758"` so the browser reserves the correct layout space before it loads.

Fixes #155

## Test plan
- [x] `bundle exec jekyll build` succeeds and the rendered `_site/index.html` includes the `width`/`height` attributes on the hero `<img>`
- [ ] Re-run Lighthouse and confirm CLS improves / this image no longer appears in "Image elements do not have explicit width and height"

🤖 Generated with [Claude Code](https://claude.com/claude-code)