### PR TITLE
Add explicit width/height to meetup thumbnail images

### DIFF
--- a/_data/picture.yml
+++ b/_data/picture.yml
@@ -18,6 +18,7 @@ presets:
       default: 690px
     attributes:
       loading: lazy
+    dimension_attributes: true
 
 media_queries:
   mobile: "(max-width: 600px)"


### PR DESCRIPTION
## Summary
- Lighthouse flagged the meetup-thumbnail `<img>` elements (homepage event cards, rendered via `jekyll_picture_tag`'s `{% picture %}` tag) as missing explicit dimensions — a contributor to the site's Cumulative Layout Shift score.
- `jekyll_picture_tag` has a built-in `dimension_attributes` preset option for exactly this case. Enabling it on the `events` preset in `_data/picture.yml` adds correct `width`/`height` attributes to the generated `<img>` tag, no template changes needed.
- Pico CSS's default `img { height: auto }` reset — the plugin's one documented prerequisite for this option — is already in place site-wide, so images still scale responsively.

Fixes #156

## Test plan
- [x] `make clean && make generate && bundle exec jekyll build` succeeds
- [x] Confirmed rendered `_site/index.html` thumbnail `<img>` tags now include `width`/`height` (e.g. `width="1104" height="1106"`), matching the source image's aspect ratio
- [ ] Re-run Lighthouse and confirm these images no longer appear in "Image elements do not have explicit width and height"

🤖 Generated with [Claude Code](https://claude.com/claude-code)