### PR TITLE
Load Pico CSS non-render-blocking via preload+swap

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -24,7 +24,8 @@
   <!-- Inclusion of JSON Linked Data -->
   {% include jsonld.html %} 
   <link rel="icon" href="{{ site.baseurl }}/assets/images/favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.pumpkin.min.css" />
+  <link rel="preload" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.pumpkin.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" />
+  <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.pumpkin.min.css" /></noscript>
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/custom.css" />
   <script defer src="https://umami.dgt.ca/script.js" data-website-id="99c82c37-f3b0-4219-8eda-7b150c5160f4"></script>
 </head>


### PR DESCRIPTION
## Summary
- Lighthouse flagged `pico.pumpkin.min.css` (loaded from jsDelivr) as the largest render-blocking request, ~759ms estimated savings.
- Per team direction, not self-hosting/vendoring the file — instead using the standard `rel="preload"` + `onload` swap pattern (with a `<noscript>` fallback) so the browser fetches it without blocking HTML parsing, then applies it as a stylesheet once it arrives.

## Trade-off to be aware of
Pico is this site's **primary** CSS framework, not a minor addition — `custom.css` builds on its classes/variables. Making it non-blocking means the page can render briefly unstyled before the swap fires (a real flash-of-unstyled-content, not just a cosmetic nit). On a fast connection this window is very short; on a slow/high-latency connection it will be more visible. Recommend reviewers check this with Chrome DevTools network throttling (e.g. "Slow 4G") before merging, to confirm the trade-off is acceptable.

Fixes #157

## Test plan
- [x] Built and served locally; confirmed via console that the `<link>`'s `rel` correctly flips from `preload` to `stylesheet` on load
- [x] No console errors after load
- [x] Confirmed Pico's theme (button colors, fonts, grid layout) is fully applied post-load
- [ ] Reviewer: check visually under throttled network conditions for FOUC severity
- [ ] Re-run Lighthouse and confirm this request no longer appears in "Render-blocking requests"

🤖 Generated with [Claude Code](https://claude.com/claude-code)